### PR TITLE
Add support for knocking on windows. Also requires players to be sneaking to knock.

### DIFF
--- a/src/main/java/online/biraw/b_s_knokondoor/B_s_KnockOnDoor.kt
+++ b/src/main/java/online/biraw/b_s_knokondoor/B_s_KnockOnDoor.kt
@@ -11,6 +11,7 @@ class B_s_KnockOnDoor : JavaPlugin() {
             private set
         var can_knock_with_tool: Boolean = true
         var can_knock_on_trapdoor: Boolean = false
+        var can_knock_on_windows: Boolean = true
     }
 
     override fun onEnable() {
@@ -26,6 +27,8 @@ class B_s_KnockOnDoor : JavaPlugin() {
             val config = YamlConfiguration.loadConfiguration(configFile)
             config.set("can_knock_on_trapdoor",true)
             config.setComments("can_knock_on_trapdoor", listOf("This determines whether you can knock on trapdoors."))
+            config.set("can_knock_on_windows", true)
+            config.setComments("can_knock_on_windows", listOf("This determines whether you can knock on windows."))
             config.set("can_knock_with_tool",false)
             config.setComments("can_knock_with_tool", listOf("If this set true, a player can knock with any item in hand.","If set false, a player can only knock if has nothing in the main hand."))
             config.save(configFile)
@@ -40,6 +43,13 @@ class B_s_KnockOnDoor : JavaPlugin() {
                 can_knock_on_trapdoor = config.getBoolean("can_knock_on_trapdoor")
             }
 
+            if (config.contains("can_knock_on_windows")) {
+                can_knock_on_windows = config.getBoolean("can_knock_on_windows")
+            } else {
+                logger.warning("'can_knock_on_windows' is not properly set in the config, so it's set to 'true' as default!")
+                config.set("can_knock_on_windows",true)
+                can_knock_on_windows = config.getBoolean("can_knock_on_windows")
+            }
 
             if (config.contains("can_knock_with_tool")) {
                 can_knock_with_tool = config.getBoolean("can_knock_with_tool")

--- a/src/main/java/online/biraw/b_s_knokondoor/PlayerInteractL.kt
+++ b/src/main/java/online/biraw/b_s_knokondoor/PlayerInteractL.kt
@@ -21,7 +21,8 @@ class PlayerInteractL : Listener {
         val player = event.player
         
 
-        if (event.action == Action.LEFT_CLICK_BLOCK && (player.inventory.itemInMainHand.isEmpty || B_s_KnockOnDoor.can_knock_with_tool)) {
+        if (event.action == Action.LEFT_CLICK_BLOCK && player.isSneaking && (player.inventory.itemInMainHand.isEmpty || B_s_KnockOnDoor.can_knock_with_tool)) {
+
             val blockType = event.clickedBlock?.type ?: return
             val location = event.clickedBlock!!.location
 
@@ -53,6 +54,27 @@ class PlayerInteractL : Listener {
                         Play(location, Sound.BLOCK_COPPER_PLACE, 6f, 0.5f)
                     }
                 else -> {}
+            }
+
+            if (B_s_KnockOnDoor.can_knock_on_windows) {
+                when (blockType) {
+                    Material.TINTED_GLASS, Material.LIGHT_BLUE_STAINED_GLASS, Material.BLUE_STAINED_GLASS,
+                    Material.GRAY_STAINED_GLASS, Material.GREEN_STAINED_GLASS, Material.RED_STAINED_GLASS,
+                    Material.YELLOW_STAINED_GLASS, Material.CYAN_STAINED_GLASS, Material.LIME_STAINED_GLASS,
+                    Material.PINK_STAINED_GLASS, Material.PURPLE_STAINED_GLASS, Material.BLACK_STAINED_GLASS,
+                    Material.BROWN_STAINED_GLASS, Material.WHITE_STAINED_GLASS, Material.ORANGE_STAINED_GLASS,
+                    Material.MAGENTA_STAINED_GLASS, Material.LIGHT_GRAY_STAINED_GLASS,
+                    Material.GLASS -> Play(location, Sound.BLOCK_BONE_BLOCK_BREAK, 10f, 0.5f)
+
+                    Material.GLASS_PANE, Material.RED_STAINED_GLASS_PANE, Material.LIGHT_BLUE_STAINED_GLASS_PANE,
+                    Material.BLUE_STAINED_GLASS_PANE, Material.GRAY_STAINED_GLASS_PANE, Material.GREEN_STAINED_GLASS_PANE,
+                    Material.CYAN_STAINED_GLASS_PANE, Material.LIGHT_GRAY_STAINED_GLASS_PANE, Material.PINK_STAINED_GLASS_PANE,
+                    Material.LIME_STAINED_GLASS_PANE, Material.BROWN_STAINED_GLASS_PANE, Material.PURPLE_STAINED_GLASS_PANE,
+                    Material.BLACK_STAINED_GLASS_PANE, Material.WHITE_STAINED_GLASS_PANE, Material.MAGENTA_STAINED_GLASS_PANE,
+                    Material.ORANGE_STAINED_GLASS_PANE, Material.YELLOW_STAINED_GLASS_PANE -> Play(location, Sound.BLOCK_COPPER_BREAK, 8f, 2f)
+
+                    else -> {}
+                }
             }
 
             if (B_s_KnockOnDoor.can_knock_on_trapdoor) {


### PR DESCRIPTION
Introduces the 'can_knock_on_windows' config option and logic to allow players to knock on glass and glass pane blocks. Updates configuration handling and event logic to support this new feature, including default values and sound effects for different window types. Also requires players to be sneaking to knock.